### PR TITLE
feat: make the formatting of buttons configurable, add example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-swaynagmode
------------
+## swaynagmode
+
 ```
 swaynagmode
 v0.2.1
@@ -12,24 +12,26 @@ To create a nag, simply use swaynag options as normal - they will be parsed and 
 
 To customise a nag, use these additional options:
 
-  short      long           description
-  -M <mode>  --mode         name of sway mode to trigger on init (default: nag)
-                            NOTE: beginning in sway version 1.2, mode names are case-sensitive
-  -D <mode>  --mode-default name of sway mode to trigger on exit (default: default)
-             --no-mode      disable triggering of sway modes
-  -i <index> --initial      index of the initially selected button (default: 0)
-  -K         --no-kill      don't add a kill command to the button actions
-  -R         --reverse      reverse the button order
+  short      long              description
+  -M <mode>  --mode            name of sway mode to trigger on init (default: nag)
+                               NOTE: beginning in sway version 1.2, mode names are case-sensitive
+  -D <mode>  --mode-default    name of sway mode to trigger on exit (default: default)
+             --no-mode         disable triggering of sway modes
+  -i <index> --initial         index of the initially selected button (default: 0)
+  -K         --no-kill         don't add a kill command to the button actions
+  -R         --reverse         reverse the button order
+             --template-active template to render currently selected button text into (default: '[%s]')
+             --template        template to render other (non-selected) button text into (default: '%s')
 
 To control an existing nag, use the following options:
 
-  short           long       description
-  -x              --exit     dismisses the nag without performing any actions
-  -S <prev|next>  --select   selects the previous/next button, wrapping around each end
-                             (as specified in arguments left to right, buttons appear from right to
-                             left)
-  -C              --confirm  accepts the selected button (indicated with [brackets]) and executes its
-                             action.
+  short           long         description
+  -x              --exit       dismisses the nag without performing any actions
+  -S <prev|next>  --select     selects the previous/next button, wrapping around each end
+                               (as specified in arguments left to right, buttons appear from right to
+                               left)
+  -C              --confirm    accepts the selected button (indicated with [brackets]) and executes its
+                               action.
 
 Global options:
   short  long       description
@@ -48,6 +50,9 @@ Example sway configuration:
     $nag_exit    $nag --exit
     $nag_confirm $nag --confirm
     $nag_select  $nag --select
+
+    # If you want fancy-pants nags, check out the --template parameters, as well as swaynag's native appearance options:
+    # $nag         exec swaynagmode --template '  %s  ' --template-active '➔ <b>%s</b>  ' --font "JetBrainsMono NF 9"
   }
   mode "nag" {
     bindsym {

--- a/swaynagmode
+++ b/swaynagmode
@@ -32,24 +32,26 @@ To create a nag, simply use swaynag options as normal - they will be parsed and 
 
 To customise a nag, use these additional options:
 
-  short      long           description
-  -M <mode>  --mode         name of sway mode to trigger on init (default: nag)
-                            NOTE: beginning in sway version 1.2, mode names are case-sensitive
-  -D <mode>  --mode-default name of sway mode to trigger on exit (default: default)
-             --no-mode      disable triggering of sway modes
-  -i <index> --initial      index of the initially selected button (default: 0)
-  -K         --no-kill      don't add a kill command to the button actions
-  -R         --reverse      reverse the button order
+  short      long              description
+  -M <mode>  --mode            name of sway mode to trigger on init (default: nag)
+                               NOTE: beginning in sway version 1.2, mode names are case-sensitive
+  -D <mode>  --mode-default    name of sway mode to trigger on exit (default: default)
+             --no-mode         disable triggering of sway modes
+  -i <index> --initial         index of the initially selected button (default: 0)
+  -K         --no-kill         don't add a kill command to the button actions
+  -R         --reverse         reverse the button order
+             --template-active template to render currently selected button text into (default: '[%s]')
+             --template        template to render other (non-selected) button text into (default: '%s')
 
 To control an existing nag, use the following options:
 
-  short           long       description
-  -x              --exit     dismisses the nag without performing any actions
-  -S <prev|next>  --select   selects the previous/next button, wrapping around each end
-                             (as specified in arguments left to right, buttons appear from right to
-                             left)
-  -C              --confirm  accepts the selected button (indicated with [brackets]) and executes its
-                             action.
+  short           long         description
+  -x              --exit       dismisses the nag without performing any actions
+  -S <prev|next>  --select     selects the previous/next button, wrapping around each end
+                               (as specified in arguments left to right, buttons appear from right to
+                               left)
+  -C              --confirm    accepts the selected button (indicated with [brackets]) and executes its
+                               action.
 
 Global options:
   short  long       description
@@ -110,6 +112,9 @@ declare msg="swaymsg"
 
 declare mode_nag="nag"
 declare mode_def="default"
+
+declare tpl_active='[%s]'
+declare tpl='%s'
 
 declare -i no_mode=0
 declare -i no_kill=0
@@ -207,6 +212,16 @@ function init() {
 
     [[ $1 =~ ^(-R|--reverse)$ ]] && {
       button_reverse=1
+      shift
+    }
+
+    [[ $1 =~ ^(--template-active)$ ]] && {
+      tpl_active=$2
+      shift
+    }
+
+    [[ $1 =~ ^(--template)$ ]] && {
+      tpl=$2
       shift
     }
 
@@ -368,9 +383,12 @@ function display_nag()  {
     [[ $no_kill -eq 0 ]] && {
       act="$prog --exit && $act"
     }
-    [[ $i -eq $btn_cursor ]] && {
-      txt="[${txt}]"
-    }
+    # shellcheck disable=SC2059
+    if [[ $i -eq $btn_cursor ]]; then
+      printf -v txt "$tpl_active" "$txt"
+    else
+      printf -v txt "$tpl" "$txt"
+    fi
     nag_cmd+=("${cmd}" "${txt}" "${act}")
     ((i++))
   done


### PR DESCRIPTION
This allows for some fancier ways of highlighting the currently selected option. I might need glasses, but the default of having `[` and `]` wrap the active button was not immediately obvious to me.

`swaynag` seems to inhibit screenshots, so please forgive me posting a photo of a computer screen showcasing the example config I've added to the readme:

![image](https://user-images.githubusercontent.com/34752364/151701075-7524b19b-0266-4497-bb0a-9226bfac4347.png)
